### PR TITLE
fix: filter out expired products from prescription search

### DIFF
--- a/app/Http/Controllers/ProductController.php
+++ b/app/Http/Controllers/ProductController.php
@@ -16,6 +16,10 @@ class ProductController extends Controller
             // Fetch products from database
             $products = Product::select('id', 'name', 'quantity as stock', 'category', 'expire_date')
                 ->where('quantity', '>', 0) // Only get products with stock
+                ->where(function($query) {
+                    $query->whereNull('expire_date') // Products without expiry date
+                          ->orWhere('expire_date', '>', now()); // Or products that haven't expired
+                })
                 ->orderBy('name')
                 ->get()
                 ->map(function ($product) {
@@ -53,6 +57,10 @@ class ProductController extends Controller
             $products = Product::select('id', 'name', 'quantity as stock', 'category')
                 ->where('name', 'LIKE', '%' . $query . '%')
                 ->where('quantity', '>', 0)
+                ->where(function($query) {
+                    $query->whereNull('expire_date') // Products without expiry date
+                          ->orWhere('expire_date', '>', now()); // Or products that haven't expired
+                })
                 ->orderBy('name')
                 ->limit(10)
                 ->get()
@@ -91,6 +99,10 @@ class ProductController extends Controller
             $products = Product::select('id', 'name', 'quantity as stock', 'category')
                 ->where('category', $category)
                 ->where('quantity', '>', 0)
+                ->where(function($query) {
+                    $query->whereNull('expire_date') // Products without expiry date
+                          ->orWhere('expire_date', '>', now()); // Or products that haven't expired
+                })
                 ->orderBy('name')
                 ->get();
 

--- a/app/Models/Product.php
+++ b/app/Models/Product.php
@@ -50,6 +50,26 @@ class Product extends Model
     }
 
     /**
+     * Check if product is expired
+     */
+    public function isExpired()
+    {
+        if (!$this->expire_date) {
+            return false; // No expiry date means it doesn't expire
+        }
+        
+        return $this->expire_date <= now();
+    }
+
+    /**
+     * Check if product is available (not expired and has stock)
+     */
+    public function isAvailable()
+    {
+        return $this->quantity > 0 && !$this->isExpired();
+    }
+
+    /**
      * Get products that are running low on stock
      */
     public static function lowStock($threshold = 10)


### PR DESCRIPTION
Prevent expired medicines from appearing in prescription form search results to ensure only safe, non-expired products can be prescribed.