### PR TITLE
fix: show only active inventory in dashboard stats

### DIFF
--- a/app/Http/Controllers/DashboardController.php
+++ b/app/Http/Controllers/DashboardController.php
@@ -27,8 +27,8 @@ class DashboardController extends Controller
     public function index()
     {
         $stats = [
-            'total_drugs' => Product::count(),
-            'product_categories' => Product::distinct('category')->count('category'),
+            'total_drugs' => Product::where('expire_date', '>=', now())->where('quantity', '>', 0)->count(),
+            'product_categories' => Product::where('expire_date', '>=', now())->where('quantity', '>', 0)->distinct('category')->count('category'),
             'expired_products' => Product::where('expire_date', '<', now())->where('quantity', '>', 0)->count(),
             'system_users' => User::count()
         ];


### PR DESCRIPTION
Exclude expired and zero-quantity drugs from total counts